### PR TITLE
patch horizontal scroll caused by `#search-header`

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -229,7 +229,7 @@ color:gray;
   background:#f8f8f8;
   width:100%;
   border-bottom:1px solid lightgray;
-  padding:2em 0em;
+  padding:2em 15px;
 }
 
 


### PR DESCRIPTION
This patch fixes the small bit of horizontal scroll found on all pages containing `<div id="search-header">`.

The scroll is caused by a lack of padding gutters on `#search-header` to account for its child div with bootstrap's `.row` CSS class:

```css
.row {
    margin-right: -15px;
    margin-left: -15px;
}
```

This patch doesn't follow your coding style's use of `em` for padding values due to your dependency on Bootstrap 3 (which uses `px` values instead). (fyi, Bootstrap4 uses `em`s and `rem`s.