### PR TITLE
include twig version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     },
     "require": {
         "php": ">=5.3.9",
+	"twig/twig": "~1.28",
         "symfony/symfony": "2.8.*",
         "doctrine/orm": "^2.4",
         "doctrine/doctrine-bundle": "1.4.*",


### PR DESCRIPTION
include twig in `composer.json` so that `composer update` does not inadvertently update to an incompatible version.
 
refs #12
