### PR TITLE
must use long PHP opening tag

### DIFF
--- a/src/AppBundle/EventListener/DatasetEditListener.php
+++ b/src/AppBundle/EventListener/DatasetEditListener.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace AppBundle\EventListener;
 


### PR DESCRIPTION
Fixing short PHP tag which was causing classloader error