### PR TITLE
revise 'funder type' field to reflect user needs

### DIFF
--- a/src/AppBundle/Form/Type/AwardType.php
+++ b/src/AppBundle/Form/Type/AwardType.php
@@ -37,7 +37,9 @@ class AwardType extends AbstractType {
       'choices'=>array('Federal, NIH'    => 'Federal, NIH',
                        'Federal, non-NIH'=> 'Federal, non-NIH',
                        'Non-federal'     => 'Non-federal',
-                       'International'   => 'International'),
+                       'Non-US'          => 'Non-US',
+                       'Private'         => 'Private'
+                      ),
     ));
     $builder->add('award_url', 'text',array(
       'required'=>false,


### PR DESCRIPTION
Revising 'funder type' options to reflect what was specified in DCCP action items list