### PR TITLE
Temporary Access Keys

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error403.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error403.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block content %}
+  <div class="col-sm-6 col-sm-offset-2">
+    <h1>Access Denied</h1>
+
+    <div class="spacer50"></div>
+    <p class="lead">
+			{{ exception.message }}
+    </p>
+  </div>
+{% endblock %}

--- a/app/Resources/views/default/tak_generate.html.twig
+++ b/app/Resources/views/default/tak_generate.html.twig
@@ -1,0 +1,45 @@
+<script>
+ 
+function copyToClipboard() {
+	//var frag=document.createDocumentFragment();
+	//var fragd=frag.appendChild(document.createElement('div'));
+	//var tlink=document.createElement('a');
+	//tlink.setAttribute('href', document.getElementById('generated-tak').getAttribute('href'));
+	//tlink.text=document.getElementById('generated-tak').text;
+	//fragd.appendChild(tlink);
+	//frag.appendChild(fragd);
+	//var thtml=fragd.innerHTML;
+	const el = document.createElement('textarea');
+	el.value = document.getElementById('generated-tak').getAttribute('href');
+	document.body.appendChild(el);
+	el.select();
+	document.execCommand('copy');
+	document.body.removeChild(el);
+};
+
+</script>
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <h4 class="modal-title" id="add_entity_modal_title">New Temporary Access Key</h4>
+</div>
+<div class="modal-body">
+
+<a id="generated-tak" href="{{ url('homepage') }}dataset/{{ dataset_uid }}?tak={{ uuid }}">Preview link for {{ dataset_title }}</a>&nbsp;:&nbsp;<a style="cursor: pointer;" onclick="copyToClipboard();">Copy to clipboard</a>
+</div>
+
+<div class="modal-footer">
+</div>
+
+<script>
+
+	if ($(".tak-panel ul").length==0) {
+		$(".tak-panel").append($("<ul>"));
+	}
+		
+	var new_tak=document.createElement("li");
+	new_tak.innerHTML='<div data-tak-uid="{{ uuid }}" class="tak-entry"><a href="{{ url('homepage') }}dataset/{{ dataset_uid }}?tak={{uuid}}">Preview link for {{ dataset_title }}</a>, Generated at {{ generated|date('Y-m-d H:i:s') }}, First Access: <em>Not yet accessed</em>&nbsp;<a class="btn-tak-remove label label-danger">Remove key</a></div>';
+	$(".tak-panel ul").append(new_tak);
+ 
+</script>

--- a/app/Resources/views/default/update_dataset_admin.html.twig
+++ b/app/Resources/views/default/update_dataset_admin.html.twig
@@ -233,6 +233,11 @@ col-sm-4
 							{% else %}
 								<em>Not yet accessed</em>
 							{% endif %}
+							{{ date("now")|date("m/d/Y") }}
+							{% if key.firstAccess and date("now") > date(key.firstAccess|date_modify(tak_ttl)) %}
+								<span class="tak-expired">expired</span>
+							{% endif %}
+
 							<a class="btn-tak-remove label label-danger">Remove key</a>
 						</div>
 					</li>

--- a/app/Resources/views/default/update_dataset_admin.html.twig
+++ b/app/Resources/views/default/update_dataset_admin.html.twig
@@ -15,6 +15,7 @@
 {% block page_scripts %}
 <script src="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0-beta.3/js/select2.min.js"></script>
 <script src="{{ asset('js/add_form.js') }}" type="text/javascript"></script>
+<script src="{{ asset('js/tak.js') }}" type="text/javascript"></script>
 {% endblock %}
 
 {% block form_group_class -%}
@@ -196,8 +197,11 @@ col-sm-4
   {% endif %}
   {{ form_widget(form._token) }}
   {{ form_widget(form.save) }}
-    </form> 
+
     {% if form.vars.data.datasetEdits is not empty %}
+ 
+ 			<legend>Change Log</legend>
+ 
         <div id="dataset-edits-panel">
             {% for edit in form.vars.data.datasetEdits %}
                 <span class="dataset-created-by">
@@ -211,7 +215,34 @@ col-sm-4
             {% endfor %}
         </div>
     {% endif %}
+		
+		
+			<legend>Temporary Access Keys</legend>
 
+			<div class="tak-panel">
+			{% if form.vars.data.tempAccessKeys is not empty %}
+
+				<ul>
+
+				{% for key in form.vars.data.tempAccessKeys %}
+					<li>
+						<div class="tak-entry" data-tak-uid="{{key.uuid}}">
+							<a href="/dataset/{{ uid }}?tak={{key.uuid}}">Preview link for {{ form.vars.data.title }}</a>, Generated at {{ key.generated|date('Y-m-d H:i:s') }}, First Access:
+							{% if key.firstAccess %}
+								{{ key.firstAccess|date('Y-m-d H:i:s') }}
+							{% else %}
+								<em>Not yet accessed</em>
+							{% endif %}
+							<a class="btn-tak-remove label label-danger">Remove key</a>
+						</div>
+					</li>
+				
+				{% endfor %}
+			</ul>
+
+		{% endif %}
+		</div>
+		<a class="btn-tak-add label label-success">Add Temporary Access Key</a>
 
 </form>
 

--- a/app/config/common/config.yml
+++ b/app/config/common/config.yml
@@ -30,6 +30,9 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
+    globals:
+        tak_ttl: '%tak_ttl%'
+
 
 # Assetic Configuration
 assetic:

--- a/app/config/parameters.yml.example
+++ b/app/config/parameters.yml.example
@@ -43,6 +43,10 @@ parameters:
     # Tag to display for local experts (if you want to specify the institution)
     local_expert_display: "Local Expert"
 
+    # Time To Live for temporary access key links (in hours), in PHP DateInterval format  
+    tak_ttl: "+3days"
+
+
   #
   # Technical stuff
   #

--- a/src/AppBundle/Controller/GeneralController.php
+++ b/src/AppBundle/Controller/GeneralController.php
@@ -13,6 +13,7 @@ use AppBundle\Form\Type\DatasetType;
 use AppBundle\Utils\Slugger;
 use Symfony\Component\Validator\Constraints as Assert;
 
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
   *  A controller handling the main search functionality, contact and About pages,
@@ -198,12 +199,11 @@ class GeneralController extends Controller
 						if ($this->container->hasParameter('tak_ttl')) {
 							$tak_ttl=$this->container->getParameter('tak_ttl');
 						}					
-						if (new \DateTime()<$tak->getFirstAccess()->add(new \DateInterval($tak_ttl))) {
+						if (new \DateTime()<$tak->getFirstAccess()->modify($tak_ttl)) {
 							$view_access=true;
 						} else {
-							throw $this->createAccessDeniedException(
-								'This temporary access key has expired.');
-						
+							throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException(
+								'This temporary access link has expired.', null, 403);
 						}
 					
 					}
@@ -217,8 +217,8 @@ class GeneralController extends Controller
 
 		if ($view_access == false) {
 
-			throw $this->createAccessDeniedException(
-				'You are not authorized to view this resource.');
+			throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException(
+				'You are not authorized to view this resource.', null, 403);
 		
 		}
 

--- a/src/AppBundle/Controller/GeneralController.php
+++ b/src/AppBundle/Controller/GeneralController.php
@@ -11,6 +11,8 @@ use AppBundle\Entity\SearchState;
 use AppBundle\Entity\Dataset;
 use AppBundle\Form\Type\DatasetType;
 use AppBundle\Utils\Slugger;
+use Symfony\Component\Validator\Constraints as Assert;
+
 
 /**
   *  A controller handling the main search functionality, contact and About pages,
@@ -169,22 +171,69 @@ class GeneralController extends Controller
         'No dataset matching ID "' . $uid . '"'
       );
     }
-    // dataset is unpublished, and user is not admin
-    if (!$dataset->getPublished() && !$this->get('security.context')->isGranted('ROLE_ADMIN')) {
-      throw $this->createAccessDeniedException(
-        'You are not authorized to view this resource.');
-    }
-    
 
-    if ($dataset->getOrigin() == 'Internal') {
-      return $this->render('default/view_dataset_internal.html.twig', array(
-        'dataset' => $dataset,
-      ));
-    } else {
-      return $this->render('default/view_dataset_external.html.twig', array(
-        'dataset' => $dataset,
-      ));
-    }
+		$view_access=true;
+
+		if (!$dataset->getPublished() && !$this->get('security.context')->isGranted('ROLE_ADMIN')) {
+			
+			$view_access=false;
+			
+			if ($request->get('tak') && !$dataset->getPublished()) {
+	
+				$tak=$this->getDoctrine()->getRepository('AppBundle:TempAccessKey')->findOneBy(array('dataset_association'=>$uid, 'uuid'=>$request->get('tak')) );
+			
+				if (sizeof($tak)>0) {
+					
+					if (!$tak->getFirstAccess()) {
+						
+				    $em = $this->getDoctrine()->getManager();
+						$tak->setFirstAccess(  new \DateTime() );
+						$em->persist($tak);
+						$em->flush();
+						$view_access=true;
+						
+					} else {
+					
+						$tak_ttl="PT72H";
+						if ($this->container->hasParameter('tak_ttl')) {
+							$tak_ttl=$this->container->getParameter('tak_ttl');
+						}					
+						if (new \DateTime()<$tak->getFirstAccess()->add(new \DateInterval($tak_ttl))) {
+							$view_access=true;
+						} else {
+							throw $this->createAccessDeniedException(
+								'This temporary access key has expired.');
+						
+						}
+					
+					}
+
+				}
+			
+			}
+
+		}
+
+
+		if ($view_access == false) {
+
+			throw $this->createAccessDeniedException(
+				'You are not authorized to view this resource.');
+		
+		}
+
+		if ($dataset->getOrigin() == 'Internal') {
+			return $this->render('default/view_dataset_internal.html.twig', array(
+				'dataset' => $dataset,
+			));
+		} else {
+			return $this->render('default/view_dataset_external.html.twig', array(
+				'dataset' => $dataset,
+			));
+		}
+  
   }
-
+  
+	
+		
 }

--- a/src/AppBundle/Controller/TakController.php
+++ b/src/AppBundle/Controller/TakController.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use AppBundle\Entity\SearchResults;
+use AppBundle\Entity\SearchState;
+use AppBundle\Entity\Dataset;
+use AppBundle\Form\Type\DatasetType;
+use AppBundle\Utils\Slugger;
+use Symfony\Component\Validator\Constraints as Assert;
+
+
+/**
+  *  A controller handling the main search functionality, contact and About pages,
+  *  dataset views, etc.
+  *
+  *   This file is part of the Data Catalog project.
+  *   Copyright (C) 2016 NYU Health Sciences Library
+  *
+  *   This program is free software: you can redistribute it and/or modify
+  *   it under the terms of the GNU General Public License as published by
+  *   the Free Software Foundation, either version 3 of the License, or
+  *   (at your option) any later version.
+  *
+  *   This program is distributed in the hope that it will be useful,
+  *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  *   GNU General Public License for more details.
+  *
+  *   You should have received a copy of the GNU General Public License
+  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  */
+class TakController extends Controller
+{
+  
+  /**
+   * Create a TAK for a dataset
+   *
+   * @param string $dataset_uid The UID of the dataset to be viewed
+   * @param Request The current HTTP request
+   *
+   * @return Response A Response instance
+   *
+   * @Route("/tak/gen/{uid}", name="tak_generate")
+   */
+
+  public function generateTak($uid, Request $request) {
+  
+		if ($this->get('security.context')->isGranted('ROLE_ADMIN')) {
+
+			$dataset=$this->getDoctrine()->getRepository('AppBundle:Dataset')->findOneBy(array('dataset_uid'=>$uid));
+
+			if ($dataset) {
+
+				do {
+					$uuid=uniqid( true );
+				} while($this->getDoctrine()->getRepository('AppBundle:TempAccessKey')->findOneBy(array('uuid'=>$uuid)));
+
+				$em = $this->getDoctrine()->getManager();
+				$tak = new \AppBundle\Entity\TempAccessKey;
+
+				$tak->setUuid( $uuid );
+				$tak->setGenerated(  new \DateTime() );
+				$tak->setDatasetAssociation($dataset);
+				
+				$em->persist($tak);
+				$em->flush();
+
+				return $this->render('default/tak_generate.html.twig', array(
+					'displayName' => 'Dataset',
+					'uuid' => $uuid,
+					'dataset_uid' => $dataset->getId(),
+					'dataset_title' => $dataset->getTitle(),
+					'generated' => $tak->getGenerated()
+					
+				));
+
+				
+			} else {
+
+				throw $this->createNotFoundException(
+					'No dataset matching ID "' . $uid . '"'
+				);
+
+			}			
+
+		} else {
+		
+			throw $this->createAccessDeniedException(
+				'You are not authorized to view this resource.');
+
+		}
+  
+	}
+
+  /**
+   * Find all the generated TAKs for a dataset
+   *
+   * @param string $dataset_uid The UID of the dataset to be viewed
+   * @param Request The current HTTP request
+   *
+   * @return Response A Response instance
+   *
+   * @Route("/tak/get/{uid}", name="tak_get_for_uid")
+   */
+  
+  public function getTaks($uid, Request $request) {
+
+		$data = ['response'=>'DENIED','keys'=>[],'dataset'=>0];
+
+		if ($this->get('security.context')->isGranted('ROLE_ADMIN')) {
+
+			$dataset=$this->getDoctrine()->getRepository('AppBundle:Dataset')->findOneBy(array('dataset_uid'=>$uid));
+
+			if ($dataset) {
+
+				$taks=$this->getDoctrine()->getRepository('AppBundle:TempAccessKey')->findBy(array('dataset_association'=>$dataset->getId() ));
+
+				foreach($taks as $t=>$v) {
+
+					$data['keys'][]=['id'=>$v->getId(), 'uuid'=>$v->getUuid(), 'generated'=>$v->getGenerated(), 'first_access'=>$v->getFirstAccess() ];
+
+				}
+				
+				$data['response']='KEYS';
+				$data['dataset']=$dataset->getId();
+				
+			} else {
+			
+				$data['response']='INVALID_UID';
+
+			}			
+
+		}
+
+		return new JsonResponse($data); 
+
+	}
+
+
+  /**
+   * Find all the generated TAKs for a dataset
+   *
+   * @param string $dataset_uid The UID of the dataset to be viewed
+   * @param Request The current HTTP request
+   *
+   * @return Response A Response instance
+   *
+   * @Route("/tak/delete/{uuid}", name="tak_delete_id")
+   */
+  
+  public function deleteTak($uuid, Request $request) {
+
+		$data = ['response'=>'DENIED', 'uuid'=>'', 'dataset'=>0];
+
+		if ($this->get('security.context')->isGranted('ROLE_ADMIN')) {
+
+			$tak=$this->getDoctrine()->getRepository('AppBundle:TempAccessKey')->findOneBy(array('uuid'=>$uuid));
+
+			if ($tak) {
+
+				$dataset=$tak->getDatasetAssociation()->getId();
+
+				$em = $this->getDoctrine()->getManager();
+				$em->remove($tak);
+        $em->flush();
+
+				$data['response']='SUCCESS';
+				$data['uuid']=$uuid;
+				$data['dataset']=$dataset;
+				
+			} else {
+			
+				$data['response']='INVALID_UUID';
+
+			}			
+
+		}
+
+		return new JsonResponse($data); 
+
+	}
+	
+		
+}

--- a/src/AppBundle/Controller/TakController.php
+++ b/src/AppBundle/Controller/TakController.php
@@ -16,8 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 
 /**
-  *  A controller handling the main search functionality, contact and About pages,
-  *  dataset views, etc.
+  *  A controller handling functions relating to Temporary Access Keys
   *
   *   This file is part of the Data Catalog project.
   *   Copyright (C) 2016 NYU Health Sciences Library

--- a/src/AppBundle/Entity/Dataset.php
+++ b/src/AppBundle/Entity/Dataset.php
@@ -444,6 +444,13 @@ class Dataset implements JsonSerializable {
    **/
   protected $dataset_edits;
 
+  /** 
+   * @ORM\OneToMany(targetEntity="TempAccessKey", mappedBy="dataset_association", cascade={"all"})
+   **/
+  protected $temp_access_keys;
+
+
+
 
   /**
    * Constructor
@@ -474,6 +481,7 @@ class Dataset implements JsonSerializable {
     $this->related_equipment = new \Doctrine\Common\Collections\ArrayCollection();
     $this->subject_of_study = new \Doctrine\Common\Collections\ArrayCollection();
     $this->authorships = new \Doctrine\Common\Collections\ArrayCollection();
+    $this->temp_access_keys = new \Doctrine\Common\Collections\ArrayCollection();
 
     // set field defaults
     $this->published = false;
@@ -2137,6 +2145,44 @@ class Dataset implements JsonSerializable {
     {
         return $this->dataset_edits;
     }
+
+
+    /**
+     * Add temp_access_keys
+     *
+     * @param \AppBundle\Entity\TempAccessKey $tempAccessKeys
+     * @return Dataset
+     */
+    public function addTempAccessKeys(\AppBundle\Entity\TempAccessKey $tempAccessKeys)
+    {
+        $this->temp_access_keys[] = $tempAccessKeys;
+
+        return $this;
+    }
+
+    /**
+     * Remove temp_access_keys
+     *
+     * @param \AppBundle\Entity\TempAccessKey $tempAccessKeys
+     */
+    public function removeTempAccessKeys(\AppBundle\Entity\TempAccessKey $tempAccessKeys)
+    {
+        $this->temp_access_keys->removeElement($tempAccessKeys);
+    }
+
+    /**
+     * Get temp_access_keys
+     *
+     * @return \Doctrine\Common\Collections\Collection 
+     */
+    public function getTempAccessKeys()
+    {
+        return $this->temp_access_keys;
+    }
+
+
+
+
 
 
     /**

--- a/src/AppBundle/Entity/TempAccessKey.php
+++ b/src/AppBundle/Entity/TempAccessKey.php
@@ -175,5 +175,25 @@ class TempAccessKey {
         return $this;
     }
 
+    /**
+     * Find if link is exired
+     *
+     * @param string $first_access
+     * @return boolean
+     */
+		public function isValid() {
+		
+			$tak_ttl="PT72H";
+			if ($this->container->hasParameter('tak_ttl')) {
+				$tak_ttl=$this->container->getParameter('tak_ttl');
+			}					
+			if (new \DateTime()<$tak->getFirstAccess()->add(new \DateInterval($tak_ttl))) {
+				return true;
+			}
+			
+			return false;
+			
+		}			
+
 
  }

--- a/src/AppBundle/Entity/TempAccessKey.php
+++ b/src/AppBundle/Entity/TempAccessKey.php
@@ -1,0 +1,179 @@
+<?php
+namespace AppBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Doctrine\Common\Collections\ArrayCollection;
+
+
+
+/**
+ * An entity for tenporary access keys
+ *
+ *   This file is part of the Data Catalog project.
+ *   Copyright (C) 2016 NYU Health Sciences Library
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * @ORM\Entity
+ * @ORM\Table(name="temp_access_keys")
+ */
+class TempAccessKey {
+  /**
+   * @ORM\Column(type="integer",name="tak_id")
+   * @ORM\Id
+   * @ORM\GeneratedValue(strategy="AUTO")
+   */
+  protected $id;
+
+  /**
+   * @ORM\Column(type="string",length=128)
+   */
+  protected $uuid;
+
+  /**
+   * @ORM\Column(type="datetime",length=128,nullable=false)
+   */
+  protected $generated;
+
+  /**
+   * @ORM\Column(type="datetime",nullable=true)
+   */
+  protected $first_access;
+  
+  /**
+   * @ORM\ManyToOne(targetEntity="Dataset")
+   * @ORM\JoinColumn(name="dataset_association",referencedColumnName="dataset_uid", nullable=FALSE)
+   */
+  protected $dataset_association;
+
+  /**
+   * Get name for display
+   *
+   * @return string
+   */
+
+	public function getDisplayName() {
+		return $this->full_name;
+	}
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+      $this->datasetAssociation = new ArrayCollection();
+    }
+
+    /**
+     * Get id
+     *
+     * @return integer 
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set datasetAssociation
+     *
+     * @param \AppBundle\Entity\Dataset $dataset_association
+     * @return TempAccessKey
+     */
+    public function setDatasetAssociation(\AppBundle\Entity\Dataset $dataset_association)
+    {
+        $this->dataset_association = $dataset_association;
+        return $this;
+    }
+
+    /**
+     * Get datasetAssociation
+     *
+     * @return \AppBundle\Entity\Dataset
+     */
+    public function getDatasetAssociation()
+    {
+        return $this->dataset_association;
+    }
+
+    /**
+     * Set uuid
+     *
+     * @param string $uuid
+     * @return TempAccessKey
+     */
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
+        return $this;
+    }
+
+    /**
+     * Get uuid
+     *
+     * @return string 
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * Set generated
+     *
+     * @param string $generated
+     * @return TempAccessKey
+     */
+    public function setGenerated($generated)
+    {
+        $this->generated = $generated;
+        return $this;
+    }
+
+    /**
+     * Get generated
+     *
+     * @return string 
+     */
+    public function getGenerated()
+    {
+        return $this->generated;
+    }
+
+    /**
+     * Get first_access
+     *
+     * @return string 
+     */
+    public function getFirstAccess()
+    {
+        return $this->first_access;
+    }
+
+    /**
+     * Set first_access
+     *
+     * @param string $first_access
+     * @return TempAccessKey
+     */
+    public function setFirstAccess($first_access)
+    {
+        $this->first_access = $first_access;
+        return $this;
+    }
+
+
+ }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -610,6 +610,17 @@ a.authors-collapse {
   margin:1em 0em;
 }
 
+/*****************
+ * TAK
+ * **************/
+
+.tak-expired {
+
+	color: red;
+	margin: 0 1em;
+	font-weight: bold;
+
+}
 
 
 /*****************

--- a/web/js/tak.js
+++ b/web/js/tak.js
@@ -1,0 +1,59 @@
+/*
+ *
+ *   This file is part of the Data Catalog project.
+ *   Copyright (C) 2016 NYU Health Sciences Library
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Functions to support the generating/managing temporary access keys
+ */
+jQuery(function($) {
+
+  /**
+   * Show the modal form when the user clicks on an "Add New" link
+   */
+  $('.btn-tak-add').click(function(e) {
+    var fieldName = $(this).attr('data-fieldname');
+    e.preventDefault();
+    var url = '/tak/gen/' + $('#dataset_dataset_uid').attr('value'); // $(this).attr('href');
+    $.get(url, function(data) {
+      $("#addEntityFormModalContent").html(data);
+      $("#addEntityFormModal").modal({show:true});
+    
+    });
+  });
+
+	$('div.tak-panel').on('click', '.btn-tak-remove', removeTAK);
+	
+
+});
+ 
+ 
+function removeTAK(e) {
+
+	$.ajax({
+		type: 'get',
+		url:  '/tak/delete/'+$(this).parent().data('tak-uid'),
+		success: function(data) {
+			if (data['response']=='SUCCESS') {
+				console.log($("div[data-tak-uid='"+data['uuid']+"']"));
+				$("div[data-tak-uid='"+data['uuid']+"']").parent().remove();
+			}
+		}
+	});
+
+
+}


### PR DESCRIPTION
Allows the creating and management of per-dataset Temporary Access Keys: unique expiring URLs for viewing unpublished dataset records of a data catalog. Requires a schema update and the inclusion of a new parameter in the parameters.yml configuration file.