### PR TITLE
Alterations to JSON-LD output

### DIFF
--- a/app/Resources/views/default/_JSONLD_output.html.twig
+++ b/app/Resources/views/default/_JSONLD_output.html.twig
@@ -1,0 +1,113 @@
+{% macro JSONLD_output(dataset) %}
+{% spaceless %}
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Dataset",
+  "name": "{{ dataset.title }}",
+  "description": "{{ dataset.description }}",
+  "dateCreated": "{{ dataset.dateAdded|date("Y-m-d") }}",
+  {% if dataset.subjectStartDate is not empty and dataset.subjectStartDate == dataset.subjectEndDate %}
+    "temporalCoverage":"{{ dataset.subjectStartDate }}",
+  {% elseif dataset.subjectStartDate is not empty %}
+    {% if dataset.subjectEndDate|trim == "Present" %}
+      "temporalCoverage":"{{ dataset.subjectStartDate }}-01-01/..",
+    {% else %}
+      "temporalCoverage":"{{ dataset.subjectStartDate }}-01-01/{{ dataset.subjectEndDate }}-12-31",
+    {% endif %}
+  {% endif %}
+  {% if dataset.subjectGeographicAreaDetails is not empty %}
+    "spatialCoverage": 
+      [
+        {% for area in dataset.subjectGeographicAreaDetails %}
+          "{{ area.getGeographicAreaDetailName }}"{% if not loop.last %}, {% endif %}
+        {% endfor %}
+      ],
+  {% elseif dataset.subjectGeographicAreas is not empty %}
+    "spatialCoverage": 
+      [
+        {% for area in dataset.subjectGeographicAreas %}
+          "{{ area.getGeographicAreaName }}"{% if not loop.last %}, {% endif %}
+        {% endfor %}
+      ],
+  {% endif %}
+  "alternateName": 
+    [{% for title in dataset.datasetAlternateTitles %}
+      "{{ title.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "keywords": 
+    [{% for kw in dataset.subjectKeywords %}
+      "{{ kw.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "author": 
+    [{% for auth in dataset.authors %}
+      {
+        "@type": "Person",
+        "name":"{{ auth.fullName }}",
+        "url":"{{ auth.bioUrl }}"}{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "citation": 
+    [{% for pub in dataset.publications %}
+      "{{ pub.citation|trim }}"{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "encoding": 
+    [{% for format in dataset.datasetFormats %}
+      {
+        "@type": "MediaObject",
+        "encodingFormat":"{{ format.getDisplayName }}"
+      }{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "publisher": 
+    [{% for pubber in dataset.publishers %}
+      {
+        "@type": "Organization",
+        "name":"{{ pubber.getDisplayName }}",
+        "url":"{{ pubber.publisherUrl }}"
+      }{% if not loop.last %}, {% endif %}
+    {% endfor %}],
+  "mainEntityOfPage": "{{ app.request.uri }}",
+  "url": "{{ app.request.uri }}",
+  "includedInDataCatalog": {
+      "@type": "DataCatalog",
+      "name": "{{ site_name }}",
+      "keywords": ["science", "dataset", "research", "data", "data catalog"],
+      "url": "{{ site_base_url }}",
+      "creator": {
+        "@type":"Organization",
+        "name":"{{ site_provider_name }}",
+        "url":"{{ site_provider_url }}",
+        "parentOrganization": {
+          "@type":"Organization",
+          "name": "{{ institution_name }}",
+          "address":"{{ institution_address }}",
+          "url":"{{ institution_url }}"
+        }
+      }
+  },
+  "sameAs": 
+    [{% for accessPoint in dataset.dataLocations %}
+      {% if 'mailto' not in accessPoint.dataAccessUrl %}
+          "{{ accessPoint.getDataAccessUrl|trim }}"{% if not loop.last %}, {% endif %}
+      {% endif %}
+    {% endfor %}],
+  "provider": 
+    {% if dataset.origin == "External" %}
+      [{% for pubber in dataset.publishers %}
+        {
+          "@type": "Organization",
+          "name":"{{ pubber.getDisplayName }}",
+          "url":"{{ pubber.publisherUrl }}"
+        }{% if not loop.last %}, {% endif %}
+      {% endfor %}]
+    {% else %}    
+      {
+        "@type": "Organization",
+        "name":"{{ site_provider_name }}",
+        "url":"{{ site_provider_url }}"
+      }
+    {% endif %}
+}
+
+</script>
+{% endspaceless %}
+{% endmacro %}

--- a/app/Resources/views/default/view_dataset_external.html.twig
+++ b/app/Resources/views/default/view_dataset_external.html.twig
@@ -1,4 +1,6 @@
 {% extends 'base.html.twig' %}
+{% from 'default/_JSONLD_output.html.twig' import JSONLD_output %}
+
 
 
 {% block page_scripts %}
@@ -68,61 +70,7 @@ $(function () {
 
 
 {% block JSONLD_output %}
-{% spaceless %}
-<script type="application/ld+json">
-{"@context": "http://schema.org",
-"@type": "Dataset",
-"name": "{{ dataset.title }}",
-"description": "{{ dataset.description }}",
-"dateCreated": "{{ dataset.dateAdded|date("Y-m-d") }}",
-"alternateName": [{% for title in dataset.datasetAlternateTitles %}"{{ title.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-"keywords": [{% for kw in dataset.subjectKeywords %}"{{ kw.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-"author": [{% for auth in dataset.authors %}
-{
-      "@type": "Person",
-      "name":"{{ auth.fullName }}",
-      "url":"{{ auth.bioUrl }}"}{% if not loop.last %}, {% endif %}{% endfor %}],
-  "citation": [{% for pub in dataset.publications %}"{{ pub.citation|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-  "encoding": [{% for format in dataset.datasetFormats %}
-{
-      "@type": "MediaObject",
-      "encodingFormat":"{{ format.getDisplayName }}"
-      }{% if not loop.last %}, {% endif %}{% endfor %}],
-  "publisher": [{% for pubber in dataset.publishers %}
-{
-      "@type": "Organization",
-      "name":"{{ pubber.getDisplayName }}",
-      "url":"{{ pubber.publisherUrl }}"}{% if not loop.last %}, {% endif %}{% endfor %}],
-"mainEntityOfPage": "{{ app.request.uri }}",
-"url": "{{ app.request.uri }}",
-"isPartOf":
-{
-"@type": "DataCatalog",
-"name": "{{ site_name }}",
-"keywords":"science, dataset, research, data, data catalog",
-"url": "{{ site_base_url }}",
-"provider": {
-  "@type":"Organization",
-  "name":"{{ site_provider_name }}",
-  "url":"{{ site_provider_url }}",
-  "parentOrganization": {
-    "@type":"Organization",
-    "name": "{{ institution_name }}",
-    "address":"{{ institution_address }}",
-    "url":"{{ institution_url }}"
-   }
- }
-},
-"sameAs": [{% for accessPoint in dataset.dataLocations %}"{{ accessPoint.getDataAccessUrl|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-"provider": [{% for provider in dataset.correspondingAuthors %}
-{
-      "@type": "Person",
-      "name":"{{ provider.fullName }}",
-      "url":"{{ provider.bioUrl }}"}{% if not loop.last %}, {% endif %}{% endfor %}]
-}
-
-</script>
-{% endspaceless %}
+{{ JSONLD_output(dataset) }}
 {% endblock %}
 
 

--- a/app/Resources/views/default/view_dataset_internal.html.twig
+++ b/app/Resources/views/default/view_dataset_internal.html.twig
@@ -1,4 +1,5 @@
 {% extends 'base.html.twig' %}
+{% from 'default/_JSONLD_output.html.twig' import JSONLD_output %}
 
 {% block page_scripts %}
 <script>
@@ -38,54 +39,7 @@ $(function () {
 
 
 {% block JSONLD_output %}
-{% spaceless %}
-<script type="application/ld+json">
-{"@context": "http://schema.org",
-"@type": "Dataset",
-"name": "{{ dataset.title }}",
-"description": "{{ dataset.description }}",
-"dateCreated": "{{ dataset.dateAdded|date("Y-m-d") }}",
-"alternateName": [{% for title in dataset.datasetAlternateTitles %}"{{ title.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-"keywords": [{% for kw in dataset.subjectKeywords %}"{{ kw.getDisplayName|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-"author": [{% for auth in dataset.authors %}
-{
-      "@type": "Person",
-      "name":"{{ auth.fullName }}",
-      "url":"{{ auth.bioUrl }}"}{% if not loop.last %}, {% endif %}{% endfor %}],
-  "citation": [{% for pub in dataset.publications %}"{{ pub.citation|trim }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-  "encoding": [{% for format in dataset.datasetFormats %}
-{
-      "@type": "MediaObject",
-      "encodingFormat":"{{ format.getDisplayName }}"
-      }{% if not loop.last %}, {% endif %}{% endfor %}],
-  "publisher": [{% for pubber in dataset.publishers %}
-{
-      "@type": "Organization",
-      "name":"{{ pubber.getDisplayName }}",
-      "url":"{{ pubber.publisherUrl }}"}{% if not loop.last %}, {% endif %}{% endfor %}],
-"mainEntityOfPage": "{{ app.request.uri }}",
-"url": "{{ app.request.uri }}",
-"isPartOf":
-{
-"@type": "DataCatalog",
-"name": "{{ site_name }}",
-"keywords":"science, dataset, research, data, data catalog",
-"url": "{{ site_base_url }}",
-"provider": {
-  "@type":"Organization",
-  "name":"{{ site_provider_name }}",
-  "url":"{{ site_provider_url }}",
-  "parentOrganization": {
-    "@type":"Organization",
-    "name": "{{ institution_name }}",
-    "address":"{{ institution_address }}",
-    "url":"{{ institution_url }}"
-   }
- }
-}
-}
-</script>
-{% endspaceless %}
+{{ JSONLD_output(dataset) }}
 {% endblock %}
 
 


### PR DESCRIPTION
Attempting to align more closely with [the Google documentation about Schema.org](https://developers.google.com/search/docs/data-types/dataset#structured-data-definitions).

Changes include:
* putting JSON-LD code into reusable Twig macro
* using "includedInDatacatalog" element rather than "isPartOf"
* adding "temporalCoverage" and "spatialCoverage" elements
* for the "provider" field: use the Publisher if dataset is External, or the "site_provider_name" parameter if Internal
* do NOT include a link in the "sameAs" field if the URL is a "mailto:" link. the "sameAs" field should link to an official/canonical version of the dataset record