### PR TITLE
Bugfix/136 collision with generated slugs

### DIFF
--- a/src/AppBundle/Entity/Person.php
+++ b/src/AppBundle/Entity/Person.php
@@ -41,12 +41,12 @@ class Person {
   protected $id;
 
   /**
-   * @ORM\Column(type="string",length=128)
+   * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $full_name;
 
   /**
-   * @ORM\Column(type="string",length=128, unique=true)
+   * @ORM\Column(type="string",length=128)
    */
   protected $slug;
 

--- a/src/AppBundle/Entity/Person.php
+++ b/src/AppBundle/Entity/Person.php
@@ -30,7 +30,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @ORM\Entity
  * @ORM\Table(name="person")
  * @UniqueEntity("kid")
- * @UniqueEntity("slug")
+ * @UniqueEntity("full_name")
  */
 class Person {
   /**

--- a/src/AppBundle/Entity/Publication.php
+++ b/src/AppBundle/Entity/Publication.php
@@ -39,7 +39,7 @@ class Publication {
   protected $id;
 
   /**
-   * @ORM\Column(type="string",length=512, unique=true)
+   * @ORM\Column(type="string",length=512)
    */
   protected $citation;
 
@@ -54,7 +54,7 @@ class Publication {
   protected $doi;
 
   /**
-   * @ORM\Column(type="string",length=128)
+   * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $slug;
 

--- a/src/AppBundle/Entity/Publication.php
+++ b/src/AppBundle/Entity/Publication.php
@@ -39,7 +39,7 @@ class Publication {
   protected $id;
 
   /**
-   * @ORM\Column(type="string",length=512)
+   * @ORM\Column(type="string",length=512, unique=true)
    */
   protected $citation;
 
@@ -54,7 +54,7 @@ class Publication {
   protected $doi;
 
   /**
-   * @ORM\Column(type="string",length=128, unique=true)
+   * @ORM\Column(type="string",length=128)
    */
   protected $slug;
 

--- a/src/AppBundle/Utils/Slugger.php
+++ b/src/AppBundle/Utils/Slugger.php
@@ -16,6 +16,10 @@ class Slugger {
    */
   static public function slugify($text)
   {
+
+    // make 8-character hash
+    $title_hash = substr(md5($text), 0, 7);
+
     // replace non letter or digits by -
     $text = preg_replace('~[^\\pL\d]+~u', '-', $text);
 
@@ -32,6 +36,8 @@ class Slugger {
     $text = preg_replace('~[^-\w]+~', '', $text);
 
     $text = substr($text, 0, 100);
+
+    $text = $text . '-' . $title_hash;
 
     if (empty($text))
     {

--- a/src/AppBundle/Utils/Slugger.php
+++ b/src/AppBundle/Utils/Slugger.php
@@ -17,7 +17,7 @@ class Slugger {
   static public function slugify($text)
   {
 
-    // make 8-character hash
+    // make 7-character hash
     $title_hash = substr(md5($text), 0, 7);
 
     // replace non letter or digits by -


### PR DESCRIPTION
A 7-character md5 hash will now be appended to all slugs to allow for cases where two entities are identical for the first 100 characters -- e.g. two different citations might start with the same author list, and would previously produce the same slug and be rejected as a duplicate. 

NOTE: The new hash addition means that any existing citations might be duplicated, since the old slugs won't have the hash. It would be preferable to use the full 'citation' field to enforce uniqueness but [it is too large to be indexed in versions of MySQL prior to 5.7](https://stackoverflow.com/a/1814594) and we need to remain compatible with 5.6. This is mitigated by the fact that the dataset entry form auto-suggests existing citations, making it easy to find existing citations.